### PR TITLE
Add explicit types file to exports config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fast-fuzzy",
-	"version": "1.11.1",
+	"version": "1.11.2",
 	"description": "Fast and tiny fuzzy-search utility",
 	"main": "lib/fuzzy.js",
 	"types": "lib/fuzzy.d.ts",
@@ -11,6 +11,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
+			"types": "./lib/fuzzy.d.ts",
 			"import": "./lib/fuzzy.mjs",
 			"require": "./lib/fuzzy.js"
 		}


### PR DESCRIPTION
With the new `exports` entry in `package.json`, it looks like both `main` and `types` are ignored. 

The default behaviour with `exports` w.r.t. types is to use and transform the filename. For instance, when required, the filename being `./lib/fuzzy.js`, the resolver will look for `./lib/fuzzy.d.ts`. 
However, for `./lib/fuzzy.mjs` when imported, the resolver will look for `./lib/fuzzy.d.mts` which doesn't exist. 

```
Could not find a declaration file for module 'fast-fuzzy'. 'REDACTED/node_modules/fast-fuzzy/lib/fuzzy.mjs' implicitly has an 'any' type.
Try `npm i --save-dev @types/fast-fuzzy` if it exists or add a new declaration (.d.ts) file containing `declare module 'fast-fuzzy';`
```

Adding and explicit `types` entry prevents this. Note that keeping `main` and `types` is useful for previous versions that don't support `exports`.

I'm unclear about the `./package.json` entry though. Is it necessary?