### PR TITLE
feat: add `useSeparatedUnicode` options and normalize Hangul consonant

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ impact on responsiveness if you intend to update search results in real time, i.
 | returnMatchData | `Bool` | return match data<sup>5</sup> | `false`
 | useDamerau | `Bool` | use damerau-levenshtein distance | `true`
 | useSellers | `Bool` | use the Sellers method for substring matching | `true`
+| useSeparatedUnicode | `Bool` | use separated unicode | `false`
 | sortBy | `sortKind` | defines which order results are returned in<sup>6</sup> | `bestMatch`
 
 <sup>3</sup> if the keySelector returns an array, the candidate will take the score of the highest scoring key.

--- a/src/fuzzy.d.ts
+++ b/src/fuzzy.d.ts
@@ -10,6 +10,7 @@ declare module 'fast-fuzzy' {
 		normalizeWhitespace?: boolean,
 		useDamerau?: boolean,
 		useSellers?: boolean,
+		useSeparatedUnicode?: boolean,
 		returnMatchData?: boolean,
 		sortBy?: sortKind,
 	}

--- a/src/fuzzy.js
+++ b/src/fuzzy.js
@@ -1,5 +1,7 @@
 import split from "graphemesplit";
 
+const splitUnicode = (str) => str.normalize("NFKD").split("");
+
 const whitespaceRegex = /^\s+$/;
 const nonWordRegex = /^[`~!@#$%^&*()\-=_+{}[\]\|\\;':",./<>?]+$/;
 
@@ -18,6 +20,7 @@ const defaultOptions = {
 	returnMatchData: false,
 	useDamerau: true,
 	useSellers: true,
+	useSeparatedUnicode: false,
 	sortBy: sortKind.bestMatch,
 };
 
@@ -33,7 +36,10 @@ function normalize(string, options) {
 	const map = [];
 	let lastWasWhitespace = true;
 	let length = 0;
-	for (const grapheme of split(lower)) {
+
+	const graphemeList = options.useSeparatedUnicode ? splitUnicode(lower) : split(lower);
+
+	for (const grapheme of graphemeList) {
 		whitespaceRegex.lastIndex = 0;
 		nonWordRegex.lastIndex = 0;
 		if (options.normalizeWhitespace && whitespaceRegex.test(grapheme)) {
@@ -43,7 +49,11 @@ function normalize(string, options) {
 				lastWasWhitespace = true;
 			}
 		} else if (!(options.ignoreSymbols && nonWordRegex.test(grapheme))) {
-			normal.push(grapheme.normalize());
+			if (options.useSeparatedUnicode) {
+				normal.push(grapheme);
+			} else {
+				normal.push(grapheme.normalize());
+			}
 			map.push(length);
 			lastWasWhitespace = false;
 		}

--- a/test.js
+++ b/test.js
@@ -43,9 +43,22 @@ describe("fuzzy", function() {
 		expect(fuzzy("high", "h💩gh")).toBe(.75);
 		// handles combining marks as single characters
 		expect(fuzzy("hi zalgo hello hello", "hi Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘ hello hello")).toBe(.75);
-
 		// handles graphemes such as hangul jamo and joined emoji as single characters
 		expect(fuzzy("high", "h깍👨‍👩‍👧‍👦h")).toBe(.5);
+	});
+
+	it("should handle unicode well(with useSeparatedUnicode)", function() {
+		const options = {useSeparatedUnicode: true};
+		// unicode characters are normalized
+		expect(fuzzy("\u212B", "\u0041\u030A", options)).toBe(1);
+		// handles high and low surrogates as multiple characters
+		expect(fuzzy("high", "h💩gh", options)).toBe(.5);
+		// handles combining marks as single characters
+		expect(fuzzy("hi zalgo hello hello", "hi Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘ hello hello", options)).toBe(.6);
+		// handles graphemes such as hangul jamo and joined emoji as multiple characters
+		expect(fuzzy("high", "h깍👨‍👩‍👧‍👦h", options)).toBe(.25);
+		// handles hangul jamo as multiple characters
+		expect(fuzzy("ㅅㄹ", "사랑", options)).toBe(.5);
 	});
 
 	describe("options", function() {
@@ -141,9 +154,23 @@ describe("search", function() {
 		expect(tSearch("high", "h💩gh")).toBe(.75);
 		// handles combining marks as single characters
 		expect(tSearch("hi zalgo hello hello", "hi Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘ hello hello")).toBe(.75);
-
 		// handles graphemes such as hangul jamo and joined emoji as single characters
 		expect(tSearch("abcde", "abc깍👨‍👩‍👧‍👦")).toBe(.6);
+	});
+
+	it("should handle unicode well(with useSeparatedUnicode)", function() {
+		const options = {returnMatchData: true, useSeparatedUnicode: true, threshold: 0.5};
+		const tSearch = (a, b) => search(a, [b], options)[0].score;
+		// unicode characters are normalized
+		expect(tSearch("\u212B", "\u0041\u030A")).toBe(1);
+		// handles high and low surrogates as multiple characters
+		expect(tSearch("high", "h💩gh")).toBe(.5);
+		// handles combining marks as multiple characters
+		expect(tSearch("hi zalgo hello hello", "hi Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘ hello hello")).toBe(.6);
+		// handles graphemes such as hangul jamo and joined emoji as multiple characters
+		expect(tSearch("abcde", "abc깍👨‍👩‍👧‍👦")).toBe(.6);
+		// handles hangul jamo as multiple characters
+		expect(tSearch("ㅅㄹ", "사랑")).toBe(.5);
 	});
 
 	describe("options", function() {


### PR DESCRIPTION
Hi, Thanks for making great library.

I added option to separate Unicode and normalize Hangul consonants to search for Hangul in this library more easily.

To my surprise, I found Hangul, my native language, in this library test code 😀.

However, it would be better if you can search quickly by entering the consonants or vowels composing the letters rather than searching with a single completed letter.

For example, if you want to search for the word `사랑(ㅅ,ㅏ,ㄹ,ㅏ,ㅇ)` as shown below, it should be searched even if you input only the consonant `ㅅ,ㄹ`. (This is the same feeling as searching for `l, v` for `love` in English.)